### PR TITLE
Fix timeline script inclusion

### DIFF
--- a/timeline.html
+++ b/timeline.html
@@ -1,5 +1,6 @@
 <link rel="stylesheet" href="./Styles/timeline.css">
-<link rel="script" href="./JS/timeline.js">
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="./JS/timeline.js"></script>
 <div class="ag-timeline-block">
     <div class="ag-timeline_title-box">
       <div class="ag-timeline_tagline">Timeline</div>


### PR DESCRIPTION
## Summary
- load timeline.js with correct `script` tag
- include jQuery for timeline page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842955f2364832ea5b72e84328fa2ad